### PR TITLE
Configure stratification in train_test_split

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ classifier = classifier.train_intent(train)
 predicted = classifier.test_intent(test)
 res = pd.DataFrame(list(zip(test.intents, predicted)), columns=['true', 'predicted'])
 ```
+If you need to configure **stratification**, use the `stratification` parameter (defaults to `"intents"` and uses the intents in the dataset as stratification basis; whatever _else_ you pass along has to conform to `sklearn.model_selection.train_test_split(stratify=)`:
+```python
+train, test = dataset.train_test_split(test_size=0.25, random_state=0, stratification=None)    # deactivate stratification (sklearn default for train_test_split)
+```
+
+### Logging
 
 Most of the code uses python logging to report its progress. To get logs printed out
 to console or Jupyter notebook, a logger needs to be configured, before the nlutests 

--- a/nlubridge/datasets.py
+++ b/nlubridge/datasets.py
@@ -311,7 +311,9 @@ class NLUdataset:
                 entities.append(entity_list)
         return NLUdataset(texts, intents, entities)
 
-    def train_test_split(self, test_size=0.25, random_state=0, stratification="intents", **args):
+    def train_test_split(
+        self, test_size=0.25, random_state=0, stratification="intents", **args
+    ):
         """
         Split dataset into train and test partitions.
 

--- a/nlubridge/datasets.py
+++ b/nlubridge/datasets.py
@@ -311,7 +311,7 @@ class NLUdataset:
                 entities.append(entity_list)
         return NLUdataset(texts, intents, entities)
 
-    def train_test_split(self, test_size=0.25, random_state=0, **args):
+    def train_test_split(self, test_size=0.25, random_state=0, stratification="intents", **args):
         """
         Split dataset into train and test partitions.
 
@@ -319,10 +319,38 @@ class NLUdataset:
         :type test_size: float
         :param random_state: random seed
         :type random_state: int
+        :param stratification: TODO
+        :type stratification: TODO
         :param args: additional args for sklearn's train_test_split
             provided as dictionary
         :type args: dict
         """
+
+        def configure_stratification():
+            """
+            Allows configuring stratification options.
+
+            The default setting, "intents", is used when we want to
+            use stratification by intent strings. If we want to use
+            anything else, we can specify it in the (parent) method's
+            stratification parameter, e.g. None, which would turn
+            stratification off (using the underlying
+            sklearn.model_selection.train_test_split() method).
+
+            The default setting, which is passed as a string, will be
+            converted into the appropriate self.intents, which isn't
+            accessible from the parent methodd's parameters.
+
+            Returns the stratify setting (either self.intents or
+            whatever is passed) to the sklearn train_test_split
+            method.
+            """
+            if stratification == "intents":
+                stratify = self.intents
+            else:
+                stratify = stratification
+            return stratify
+
         (
             texts_train,
             texts_test,
@@ -334,7 +362,7 @@ class NLUdataset:
             self.texts,
             self.intents,
             self.entities,
-            stratify=self.intents,
+            stratify=configure_stratification(),
             test_size=test_size,
             random_state=random_state,
             **args


### PR DESCRIPTION
This commit makes a backwards-compatible change; the default behaviour
is the same as before, but now you can use the stratification parameter
of the method to pass anything you need to sklearn's train_test_split stratify
parameter.