### PR TITLE
intent and entity recognition for Rasa 2.x and 3.x (+ support for Rasa's yml- and json-format)

### DIFF
--- a/nlubridge/__init__.py
+++ b/nlubridge/__init__.py
@@ -3,6 +3,6 @@
 # This software is distributed under the terms of the MIT license
 # which is available at https://opensource.org/licenses/MIT
 """Provides a unified API to several popular intent recognition applications"""
-from .datasets import NLUdataset, OUT_OF_SCOPE_TOKEN  # noqa: F401
+from .datasets import NLUdataset, OUT_OF_SCOPE_TOKEN, EntityKeys  # noqa: F401
 
 __version__ = "0.1.0"

--- a/nlubridge/datasets.py
+++ b/nlubridge/datasets.py
@@ -33,7 +33,7 @@ class NLUdataset:
         self,
         texts: List[str],
         intents: List[str] = None,
-        entities: List[dict] = None,
+        entities: List[List[dict]] = None,
         out_of_scope=False,
         max_intent_length=None,
         seed=42,
@@ -164,7 +164,7 @@ class NLUdataset:
         self.texts, self.intents, self.entities = zip(*self.data)
         return self
 
-    def sample(self, size=0.1, random_state=0):
+    def sample(self, size=0.1, random_state=0, stratification="intents"):
         """
         Sample the dataset preserving intent proportions.
 
@@ -173,11 +173,17 @@ class NLUdataset:
         :type size: float or int
         :param random_state: seed for random processes
         :type random_state: int
+        :param stratification: If not None, data is split in a stratified fashion, using this as the class labels.
+                               Default is using the intent labels for stratification.
         """
         if isinstance(size, numbers.Integral):
             size = size / self.n_samples
 
-        _, sampled = self.train_test_split(test_size=size, random_state=random_state)
+        _, sampled = self.train_test_split(
+            test_size=size,
+            random_state=random_state,
+            stratification=stratification
+        )
         return sampled
 
     def filter_by_intent_name(

--- a/nlubridge/vendors/__init__.py
+++ b/nlubridge/vendors/__init__.py
@@ -10,5 +10,10 @@ with try_import() as optional_watson_import:
     from .watson import Watson  # noqa: F401
     from .spacy import SpacyClassifier  # noqa: F401
     from .telekom import TelekomModel  # noqa: F401
-    from .rasa import Rasa  # noqa: F401
     from .fasttext import FastText  # noqa: F401
+
+with try_import() as optional_rasa_import:
+    from .rasa import Rasa  # noqa: F401
+
+with try_import() as optional_rasa3_import:
+    from .rasa3 import Rasa3

--- a/nlubridge/vendors/config/rasa_nlu_config.yml
+++ b/nlubridge/vendors/config/rasa_nlu_config.yml
@@ -1,3 +1,5 @@
+recipe: default.v1
+
 language: "de"
 pipeline:
 # # No configuration for the NLU pipeline was provided. The following default pipeline was used to train your model.

--- a/nlubridge/vendors/vendors.py
+++ b/nlubridge/vendors/vendors.py
@@ -28,20 +28,29 @@ class Vendor(BaseEstimator, ClassifierMixin):
         fake_data = NLUdataset(texts, intents, entities=[])
         self.train_intent(fake_data)
 
+    def train(self, dataset: NLUdataset):
+        """
+        Train intent and/or entity classification
+
+        :param dataset: Training data
+        """
+        raise NotImplementedError
+
+    def test(self, dataset: NLUdataset) -> NLUdataset:
+        """
+        Test a given dataset and obtain the intent and/or entity classification results in the NLUdataset format
+
+        :param dataset: Input dataset to be tested
+        :return: NLUdataset object comprising the classification results
+        """
+        raise NotImplementedError
+
     def train_intent(self, dataset):
         """Train intent classification."""
         raise NotImplementedError
 
     def test_intent(self, dataset):
         """Test intent classification."""
-        raise NotImplementedError
-
-    def train_entity(self, dataset):
-        """Train entity recognition."""
-        raise NotImplementedError
-
-    def test_entity(self, dataset):
-        """Test entity recognition."""
         raise NotImplementedError
 
     @property

--- a/tests/fixtures/rasa3_nlu.yml
+++ b/tests/fixtures/rasa3_nlu.yml
@@ -1,0 +1,11 @@
+version: "3.0"
+nlu:
+- intent: restaurant_search
+  examples: |
+    - i'm looking for a place to eat
+    - testing umläuts
+    - show me [chinese](cuisine) restaurants
+    - show me a [mexican](cuisine) place in the [centre]{"entity": "location", "role": "restaurant_location"}
+- intent: affirm
+  examples: |
+    - yes

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -19,11 +19,11 @@ texts = [
 intents = ["BookFlight", "GetWeather", "GetWeather"]
 entities = [
     [
-        {"entity": "Location::From", "start": 22, "end": 26},
-        {"entity": "Location::To", "start": 31, "end": 37},
+        {"entity": "Location::From", "start": 22, "end": 27},
+        {"entity": "Location::To", "start": 31, "end": 38},
     ],
-    [{"entity": "Location", "start": 27, "end": 33}],
-    [{"entity": "Location", "start": 23, "end": 27}],
+    [{"entity": "Location", "start": 27, "end": 34}],
+    [{"entity": "Location", "start": 22, "end": 28}],
 ]
 
 

--- a/tests/testing_data.py
+++ b/tests/testing_data.py
@@ -12,10 +12,10 @@ class ToyDataset(NLUdataset):
         intents = ["BookFlight", "GetWeather"]
         entities = [
             [
-                {"entity": "LocationFrom", "start": 22, "end": 26},
-                {"entity": "LocationTo", "start": 31, "end": 37},
+                {"entity": "LocationFrom", "start": 22, "end": 27},
+                {"entity": "LocationTo", "start": 31, "end": 38},
             ],
-            [{"entity": "Location", "start": 27, "end": 33}],
+            [{"entity": "Location", "start": 27, "end": 34}],
         ]
         super().__init__(texts, intents, entities, **kw_args)
 


### PR DESCRIPTION
This pull requests is a replacement of the previous pull request https://github.com/telekom/nlu-bridge/pull/10

It comprises all changes from the previous pull request:
- support for Rasa 3.x
- entity recognition added for Rasa 2.x and Rasa 3.x
- adapted test case for Rasa 2.x and 3.x (intent and entity recognition)
- a few small changes

New changes:
- NLUdatasets can now be imported/exported in Rasa's yml- or json-format (`write_data(..)`, `load_data(..)`)

In any case I'd like to discuss with you the changes in general (e.g. approach for entity recognition) before we discuss the concrete details of this pull request.