### PR TITLE
removing base classes for Vendor

### DIFF
--- a/nlubridge/vendors/char_ngram_intent_classifier.py
+++ b/nlubridge/vendors/char_ngram_intent_classifier.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 
 class CharNgramIntentClassifier(Vendor):
-
     def __init__(self, anomaly_clf_nu=0):
         """
         Interface to a custom intent classifier based on character n-grams.

--- a/nlubridge/vendors/char_ngram_intent_classifier.py
+++ b/nlubridge/vendors/char_ngram_intent_classifier.py
@@ -35,19 +35,19 @@ class CharNgramIntentClassifier(Vendor):
         :type anomaly_clf_nu: float
         """
         self._alias = self.name
-        self.clf = Model1(
+        self._clf = Model1(
             none_class=OUT_OF_SCOPE_TOKEN, verbose=False, anomaly_clf_nu=anomaly_clf_nu
         )
 
     def train_intent(self, dataset):  # noqa D102
         X = dataset.texts
         y = dataset.intents
-        self.clf.fit(X, y)
+        self._clf.fit(X, y)
         return self
 
     def test_intent(self, dataset, return_probs=False):  # noqa D102
         X = dataset.texts
-        intents, probs = self.clf.predict(X, return_probs=True)
+        intents, probs = self._clf.predict(X, return_probs=True)
         intents = list(intents)
         probs = list(probs)
         if return_probs:

--- a/nlubridge/vendors/char_ngram_intent_classifier.py
+++ b/nlubridge/vendors/char_ngram_intent_classifier.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 
 class CharNgramIntentClassifier(Vendor):
-    alias = "char_ngram"
 
     def __init__(self, anomaly_clf_nu=0):
         """
@@ -35,6 +34,7 @@ class CharNgramIntentClassifier(Vendor):
             off)
         :type anomaly_clf_nu: float
         """
+        self._alias = self.name
         self.clf = Model1(
             none_class=OUT_OF_SCOPE_TOKEN, verbose=False, anomaly_clf_nu=anomaly_clf_nu
         )

--- a/nlubridge/vendors/fasttext.py
+++ b/nlubridge/vendors/fasttext.py
@@ -29,7 +29,6 @@ DEFAULT_CONFIG = {
 
 
 class FastText(Vendor):
-    alias = "fasttext"
 
     def __init__(self, epochs=10000, lr=0.1, config=DEFAULT_CONFIG):
         """
@@ -64,6 +63,7 @@ class FastText(Vendor):
         :param config: dictionary with additional parameters
         :type config: dict
         """
+        self._alias = self.name
         self.epochs = epochs
         self.lr = lr
         self.model = None

--- a/nlubridge/vendors/fasttext.py
+++ b/nlubridge/vendors/fasttext.py
@@ -29,7 +29,6 @@ DEFAULT_CONFIG = {
 
 
 class FastText(Vendor):
-
     def __init__(self, epochs=10000, lr=0.1, config=DEFAULT_CONFIG):
         """
         Interface for the FastText classifier.

--- a/nlubridge/vendors/fasttext.py
+++ b/nlubridge/vendors/fasttext.py
@@ -64,17 +64,17 @@ class FastText(Vendor):
         :type config: dict
         """
         self._alias = self.name
-        self.epochs = epochs
-        self.lr = lr
-        self.model = None
-        self.config = config
+        self._epochs = epochs
+        self._lr = lr
+        self._model = None
+        self._config = config
 
     def train_intent(self, dataset):
         """Train intent classifier."""
         train_data = self._convert(dataset)
         logger.info(f"Training on {dataset.n_samples} samples")
-        self.model = train_supervised(
-            input=train_data, epoch=self.epochs, lr=self.lr, **self.config
+        self._model = train_supervised(
+            input=train_data, epoch=self._epochs, lr=self._lr, **self._config
         )
         # remove tempfile
         os.remove(train_data)
@@ -88,7 +88,7 @@ class FastText(Vendor):
         for text in dataset.texts:
             text = self._clean_text(text)
             text = "".join(text.splitlines())
-            result = self.model.predict(text)
+            result = self._model.predict(text)
             intent = result[0][0]
             intent = intent[len("__label__") :]
             prob = result[1][0]

--- a/nlubridge/vendors/luis.py
+++ b/nlubridge/vendors/luis.py
@@ -28,7 +28,6 @@ def _unwrap_self(arg, **kwarg):
 
 
 class Luis(Vendor):
-    alias = "luis"
 
     AUTHORING_RATE_LIMIT = 4.99  # queries per second
     SUBSCRIPTION_RATE_LIMIT = 4.9  # queries per second
@@ -45,6 +44,7 @@ class Luis(Vendor):
         version="0.1",
     ):
         """Interface for Microsoft LUIS."""
+        self._alias = self.name
         endpoint = endpoint or os.getenv("LUIS_ENDPOINT")
         if endpoint is None:
             ValueError(

--- a/nlubridge/vendors/rasa2.py
+++ b/nlubridge/vendors/rasa2.py
@@ -36,7 +36,6 @@ ENTITY_KEY_VALUE = "value"  # Rasa provides an explicit value parameter for its 
 
 
 class Rasa2(Vendor):
-    alias = "rasa2"
 
     def __init__(self, model_config: Optional[str] = None):
         """
@@ -49,6 +48,7 @@ class Rasa2(Vendor):
 
         :param model_config: filepath to a Rasa config file
         """
+        self._alias = self.name
         self.config = model_config
         self.interpreter = None
 

--- a/nlubridge/vendors/rasa2.py
+++ b/nlubridge/vendors/rasa2.py
@@ -49,8 +49,8 @@ class Rasa2(Vendor):
         :param model_config: filepath to a Rasa config file
         """
         self._alias = self.name
-        self.config = model_config
-        self.interpreter = None
+        self._config = model_config
+        self._interpreter = None
 
     def train(self, dataset: NluDataset) -> Rasa2:
         """
@@ -59,10 +59,10 @@ class Rasa2(Vendor):
         :param dataset: Training data
         :return: It's own Rasa object
         """
-        self.config = self.config if self.config else DEFAULT_INTENT_RASA_CONFIG_PATH
+        self._config = self._config if self._config else DEFAULT_INTENT_RASA_CONFIG_PATH
         training_data = self._convert(dataset)
-        trainer = Trainer(config.load(self.config))
-        self.interpreter = trainer.train(training_data)
+        trainer = Trainer(config.load(self._config))
+        self._interpreter = trainer.train(training_data)
         return self
 
     def train_intent(self, dataset: NluDataset) -> Rasa2:
@@ -92,10 +92,10 @@ class Rasa2(Vendor):
         intents: List[str] = []
         n_best_lists: List[List[dict]] = []
         entities_list: List[List[dict]] = []
-        if self.interpreter is None:
+        if self._interpreter is None:
             raise Exception("Rasa2 classifier has to be trained first!")
         for text in dataset.texts:
-            result = self.interpreter.parse(text)
+            result = self._interpreter.parse(text)
             intent = result.get(INTENT, {}).get(INTENT_NAME_KEY)
             entities = [
                 {
@@ -135,10 +135,10 @@ class Rasa2(Vendor):
         """
         intents: List[str] = []
         probs: List[float] = []
-        if self.interpreter is None:
+        if self._interpreter is None:
             raise Exception("Rasa2 classifier has to be trained first!")
         for text in dataset.texts:
-            result = self.interpreter.parse(text)
+            result = self._interpreter.parse(text)
             intent = result.get(INTENT, {}).get(INTENT_NAME_KEY)
             prob = result.get(INTENT, {}).get(PREDICTED_CONFIDENCE_KEY)
             intents.append(intent)

--- a/nlubridge/vendors/rasa2.py
+++ b/nlubridge/vendors/rasa2.py
@@ -36,7 +36,6 @@ ENTITY_KEY_VALUE = "value"  # Rasa provides an explicit value parameter for its 
 
 
 class Rasa2(Vendor):
-
     def __init__(self, model_config: Optional[str] = None):
         """
         Interface for the `Rasa NLU <https://github.com/RasaHQ/rasa>`_.

--- a/nlubridge/vendors/rasa3.py
+++ b/nlubridge/vendors/rasa3.py
@@ -36,7 +36,6 @@ DEFAULT_INTENT_RASA_CONFIG_PATH = os.path.join(
 
 
 class Rasa3(Vendor):
-    alias = "rasa3"
 
     def __init__(self, model_config: Optional[str] = None):
         """
@@ -49,6 +48,7 @@ class Rasa3(Vendor):
 
         :param model_config: filepath to a Rasa config file
         """
+        self._alias = self.name
         self.config = model_config
         self.agent = None
 

--- a/nlubridge/vendors/rasa3.py
+++ b/nlubridge/vendors/rasa3.py
@@ -36,7 +36,6 @@ DEFAULT_INTENT_RASA_CONFIG_PATH = os.path.join(
 
 
 class Rasa3(Vendor):
-
     def __init__(self, model_config: Optional[str] = None):
         """
         Interface for the `Rasa NLU <https://github.com/RasaHQ/rasa>`_.

--- a/nlubridge/vendors/spacy.py
+++ b/nlubridge/vendors/spacy.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 class Spacy(Vendor):
-    alias = "spacy"
 
     def __init__(self, n_iter=10, config=None, language="en"):
         """
@@ -30,6 +29,7 @@ class Spacy(Vendor):
         :param language: Language string (default: "en")
         :type language: str
         """
+        self._alias = self.name
         self.nlp = spacy.blank(language)
         if not config:
             config = {

--- a/nlubridge/vendors/spacy.py
+++ b/nlubridge/vendors/spacy.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 class Spacy(Vendor):
-
     def __init__(self, n_iter=10, config=None, language="en"):
         """
         Interface for the Spacy intent classifier.

--- a/nlubridge/vendors/spacy.py
+++ b/nlubridge/vendors/spacy.py
@@ -30,19 +30,19 @@ class Spacy(Vendor):
         :type language: str
         """
         self._alias = self.name
-        self.nlp = spacy.blank(language)
+        self._nlp = spacy.blank(language)
         if not config:
             config = {
                 "threshold": 0.5,
                 "model": DEFAULT_SINGLE_TEXTCAT_MODEL,
             }
-        self.textcat = self.nlp.add_pipe("textcat", config=config)
-        self.n_iter = n_iter
+        self._textcat = self._nlp.add_pipe("textcat", config=config)
+        self._n_iter = n_iter
 
     def _convert(self, dataset):
         examples = []
         for text, intent in zip(dataset.texts, dataset.intents):
-            doc = self.nlp.make_doc(text)
+            doc = self._nlp.make_doc(text)
             cats = {
                 intent: True if intent == each else False
                 for each in dataset.unique_intents
@@ -56,18 +56,18 @@ class Spacy(Vendor):
         examples = self._convert(dataset)
 
         get_examples = lambda: examples  # noqa: E731
-        optimizer = self.nlp.initialize(get_examples)
-        for itn in range(self.n_iter):
+        optimizer = self._nlp.initialize(get_examples)
+        for itn in range(self._n_iter):
             random.shuffle(examples)
             for example in examples:
-                self.nlp.update([example], sgd=optimizer)
+                self._nlp.update([example], sgd=optimizer)
 
     def test_intent(self, dataset, return_probs=False):
         """Test intent classifier."""
         intents = []
         probs = []
         for text in dataset.texts:
-            doc = self.nlp(text)
+            doc = self._nlp(text)
             intent = max(doc.cats, key=doc.cats.get)
             prob = doc.cats[intent]
             intents.append(intent)

--- a/nlubridge/vendors/tfidf_intent_classifier.py
+++ b/nlubridge/vendors/tfidf_intent_classifier.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class TfidfIntentClassifier(Vendor):
-    alias = "tfidf"
 
     def __init__(self):
         """
@@ -34,6 +33,7 @@ class TfidfIntentClassifier(Vendor):
             * Can't use external information (ex: pretrained word
               embeddings)
         """
+        self._alias = self.name
         self.clf = Pipeline(
             [
                 ("vect", CountVectorizer()),

--- a/nlubridge/vendors/tfidf_intent_classifier.py
+++ b/nlubridge/vendors/tfidf_intent_classifier.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class TfidfIntentClassifier(Vendor):
-
     def __init__(self):
         """
         Interface to a TFIDF text classifier.

--- a/nlubridge/vendors/tfidf_intent_classifier.py
+++ b/nlubridge/vendors/tfidf_intent_classifier.py
@@ -34,7 +34,7 @@ class TfidfIntentClassifier(Vendor):
               embeddings)
         """
         self._alias = self.name
-        self.clf = Pipeline(
+        self._clf = Pipeline(
             [
                 ("vect", CountVectorizer()),
                 ("tfidf", TfidfTransformer()),
@@ -58,18 +58,18 @@ class TfidfIntentClassifier(Vendor):
         logger.info(f"Training on {dataset.n_samples} samples")
         X = dataset.texts
         y = dataset.intents
-        self.clf.fit(X, y)
+        self._clf.fit(X, y)
         return self
 
     def test_intent(self, dataset, return_probs=False):
         """Test intent classifier."""
         logger.info(f"Testing on {dataset.n_samples} samples")
         X = dataset.texts
-        probs = self.clf.predict_proba(X)
+        probs = self._clf.predict_proba(X)
         pred_idxs = probs.argmax(axis=1)
         winner_class_probs = probs.max(axis=1)
         winner_class_probs = list(winner_class_probs)
-        intents = self.clf.classes_[pred_idxs]
+        intents = self._clf.classes_[pred_idxs]
         intents = list(intents)
 
         if return_probs:

--- a/nlubridge/vendors/vendor.py
+++ b/nlubridge/vendors/vendor.py
@@ -15,10 +15,12 @@ class Vendor:
 
     @property
     def alias(self):
+        """Return alias, which is a customizable name of the instance"""
         return self._alias
 
     @alias.setter
     def alias(self, value):
+        """Set alias, which is a customizable name of the instance"""
         self._alias = value
 
     def train(self, dataset: NluDataset):

--- a/nlubridge/vendors/vendor.py
+++ b/nlubridge/vendors/vendor.py
@@ -15,12 +15,12 @@ class Vendor:
 
     @property
     def alias(self):
-        """Return alias, which is a customizable name of the instance"""
+        """Return alias, which is a customizable name of the instance."""
         return self._alias
 
     @alias.setter
     def alias(self, value):
-        """Set alias, which is a customizable name of the instance"""
+        """Set alias, which is a customizable name of the instance."""
         self._alias = value
 
     def train(self, dataset: NluDataset):

--- a/nlubridge/vendors/vendor.py
+++ b/nlubridge/vendors/vendor.py
@@ -5,13 +5,12 @@
 import random
 
 import numpy as np
-from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.metrics import accuracy_score, classification_report, f1_score
 
 from ..nlu_dataset import OUT_OF_SCOPE_TOKEN, NluDataset
 
 
-class Vendor():
+class Vendor:
     """Abstract class for a vendor."""
 
     # TODO: Is this really a reliable method for the purpose?

--- a/nlubridge/vendors/vendor.py
+++ b/nlubridge/vendors/vendor.py
@@ -2,30 +2,24 @@
 # This software is distributed under the terms of the MIT license
 # which is available at https://opensource.org/licenses/MIT
 
-import random
-
-import numpy as np
-from sklearn.metrics import accuracy_score, classification_report, f1_score
-
-from ..nlu_dataset import OUT_OF_SCOPE_TOKEN, NluDataset
+from ..nlu_dataset import NluDataset
 
 
 class Vendor:
     """Abstract class for a vendor."""
 
-    # TODO: Is this really a reliable method for the purpose?
-    def fake_train_intent(self, data):
-        """
-        Train vendor with noise.
+    @property
+    def name(self):
+        """Return the class's name as a hint to the vendor name."""
+        return self.__class__.__name__
 
-        This method has the purpose of resetting any cache that
-        a vendor system might be using to memorize labels
-        """
-        texts = data.texts
-        intents = data.intents
-        random.shuffle(intents)
-        fake_data = NluDataset(texts, intents, entities=[])
-        self.train_intent(fake_data)
+    @property
+    def alias(self):
+        return self._alias
+
+    @alias.setter
+    def alias(self, value):
+        self._alias = value
 
     def train(self, dataset: NluDataset):
         """
@@ -54,70 +48,3 @@ class Vendor:
     def test_intent(self, dataset):
         """Test intent classification."""
         raise NotImplementedError
-
-    @property
-    def name(self):
-        """Return the class's name as a hint to the vendor name."""
-        return self.__class__.__name__
-
-    def f1_score(self, test_dataset, average="micro"):
-        """
-        Predict intent f1 score.
-
-        Predict intents for samples in test_dataset and compute
-        f1 score by comparing predictions to labels given in dataset
-        """
-        y_pred = self.test_intent(test_dataset)
-        y_true = test_dataset.intents
-        return f1_score(y_true, y_pred, average=average)
-
-    def out_of_scope_accuracy(self, test_dataset):
-        """Test OOS accuracy."""
-        y_pred = self.test_intent(test_dataset)
-        y_true = np.full_like(y_pred, OUT_OF_SCOPE_TOKEN)
-        return accuracy_score(y_true, y_pred)
-
-    def classification_report(self, test_dataset):
-        """
-        Compute intent classification report.
-
-        Predict intents for samples in test_dataset and compute a
-        scikit-learn classification report by comparing predictions to
-        labels given in dataset.
-        """
-        y_pred = self.test_intent(test_dataset)
-        y_true = test_dataset.intents
-        return classification_report(y_true, y_pred)
-
-    def fit(self, X, y=None):
-        """
-        scikit-learn compatibility.
-
-        This method directly accepts texts and intents instead of a
-        NLUdataset.
-        """
-        texts = X
-        intents = y
-        ds = NluDataset(texts, intents)
-        self.train_intent(ds)
-        return self
-
-    def predict(self, X, y=None):
-        """
-        scikit-learn compatibility.
-
-        This method directly accepts texts and intents instead of a
-        dataset.
-        """
-        texts = X
-        intents = y
-        ds = NluDataset(texts, intents)
-        y = self.test_intent(ds)
-        return y
-
-    def score(self, X, y=None, average="micro"):
-        """scikit-learn compatibility."""
-        texts = X
-        intents = y
-        ds = NluDataset(texts, intents)
-        return self.f1_score(ds, average=average)

--- a/nlubridge/vendors/vendor.py
+++ b/nlubridge/vendors/vendor.py
@@ -11,7 +11,7 @@ from sklearn.metrics import accuracy_score, classification_report, f1_score
 from ..nlu_dataset import OUT_OF_SCOPE_TOKEN, NluDataset
 
 
-class Vendor(BaseEstimator, ClassifierMixin):
+class Vendor():
     """Abstract class for a vendor."""
 
     # TODO: Is this really a reliable method for the purpose?

--- a/nlubridge/vendors/watson_assistant.py
+++ b/nlubridge/vendors/watson_assistant.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class WatsonAssistant(Vendor):
-    alias = "watson_assistant"
 
     def __init__(
         self,
@@ -66,6 +65,7 @@ class WatsonAssistant(Vendor):
         :param use_bulk: if True (default) uses bulk_classify method
         :type use_bulk: bool
         """
+        self._alias = self.name
         api_key = api_key or os.getenv("WATSON_API_KEY")
         if api_key is None:
             ValueError(

--- a/nlubridge/vendors/watson_assistant.py
+++ b/nlubridge/vendors/watson_assistant.py
@@ -84,11 +84,11 @@ class WatsonAssistant(Vendor):
                 "workspace_name not passed and not found under environment "
                 "variable WATSON_WORKSPACE_NAME"
             )
-        self.assistant = self._connect(endpoint, api_key, api_version)
-        self.workspace_name = workspace_name
-        self.workspace_id = self._get_workspace_id()
-        self.max_workers = max_workers
-        self.use_bulk = use_bulk
+        self._assistant = self._connect(endpoint, api_key, api_version)
+        self._workspace_name = workspace_name
+        self._workspace_id = self._get_workspace_id()
+        self._max_workers = max_workers
+        self._use_bulk = use_bulk
 
     def set_bulk(self, use_bulk):
         """
@@ -97,7 +97,7 @@ class WatsonAssistant(Vendor):
         :param use_bulk: True means use bulk method for testing
         :type use_bulk: bool
         """
-        self.use_bulk = use_bulk
+        self._use_bulk = use_bulk
 
     def set_max_workers(self, max_workers):
         """
@@ -108,12 +108,12 @@ class WatsonAssistant(Vendor):
         :param max_workers: max_workers to use for parallel requests
         :type max_workers: int
         """
-        self.max_workers = max_workers
+        self._max_workers = max_workers
 
     @property
     def _is_trained(self):
-        response = self.assistant.get_workspace(
-            workspace_id=self.workspace_id, export=False
+        response = self._assistant.get_workspace(
+            workspace_id=self._workspace_id, export=False
         ).get_result()
         return response["status"] == "Available"
 
@@ -163,7 +163,7 @@ class WatsonAssistant(Vendor):
         if not self._is_trained:
             raise RuntimeError("Watson Assistant workspace has not yet been trained")
 
-        if not self.use_bulk:
+        if not self._use_bulk:
             responses = self._get_wa_response_in_session(dataset)
         else:
             responses = self._get_wa_response_in_batches(dataset)
@@ -236,15 +236,15 @@ class WatsonAssistant(Vendor):
         return data_wa_format
 
     def _get_workspace_id(self):
-        response = self.assistant.list_workspaces().get_result()
+        response = self._assistant.list_workspaces().get_result()
         for workspace in response["workspaces"]:
-            if workspace["name"] == self.workspace_name:
+            if workspace["name"] == self._workspace_name:
                 return workspace["workspace_id"]
         raise ValueError("Workspace could not be found.")
 
     def _delete_workspace(self):
         """Delete a workspace by its name."""
-        response = self.assistant.delete_workspace(self.workspace_id)
+        response = self._assistant.delete_workspace(self._workspace_id)
         status_code = response.get_status_code()
         return status_code == "200"
 
@@ -257,13 +257,13 @@ class WatsonAssistant(Vendor):
         workspace and creates a new one under the same name
         (workspace_id is updated).
         """
-        logger.info(f"Clearing workspace {self.workspace_id}")
+        logger.info(f"Clearing workspace {self._workspace_id}")
         # TODO: handle failures of delete_workspace (and fix unused variable 'success')
         success = self._delete_workspace()  # noqa: F841
-        response = self.assistant.create_workspace(
-            name=self.workspace_name, description="created via api", language="de"
+        response = self._assistant.create_workspace(
+            name=self._workspace_name, description="created via api", language="de"
         ).get_result()
-        self.workspace_id = response["workspace_id"]
+        self._workspace_id = response["workspace_id"]
 
     def _upload_samples(self, dataset):
         self._clear_workspace()
@@ -271,8 +271,8 @@ class WatsonAssistant(Vendor):
         logger.info("Uploading samples")
         for intent in intents:
             # TODO: handle failures (and fix unused variable 'response')
-            response = self.assistant.create_intent(  # noqa: F841
-                workspace_id=self.workspace_id,
+            response = self._assistant.create_intent(  # noqa: F841
+                workspace_id=self._workspace_id,
                 intent=intent["intent"],
                 examples=intent["examples"],
             ).get_result()
@@ -280,8 +280,8 @@ class WatsonAssistant(Vendor):
     def _get_wa_response(self, query):
         """Get the NLU result for a single message."""
         query = self.validate_text(query)
-        response = self.assistant.message(
-            workspace_id=self.workspace_id,
+        response = self._assistant.message(
+            workspace_id=self._workspace_id,
             input={"text": query},
             alternate_intents=True,
         )
@@ -309,13 +309,13 @@ class WatsonAssistant(Vendor):
 
         with requests.Session() as session:
             session.auth = requests.auth.HTTPBasicAuth(
-                "apikey", self.assistant.authenticator.token_manager.apikey
+                "apikey", self._assistant.authenticator.token_manager.apikey
             )
             session.headers.update({"Content-Type": "application/json"})
             url = "{url}/v1/workspaces/{ws_id}/bulk_classify?version={version}".format(
-                url=self.assistant.service_url,
-                ws_id=self.workspace_id,
-                version=self.assistant.version,
+                url=self._assistant.service_url,
+                ws_id=self._workspace_id,
+                version=self._assistant.version,
             )
             all_results = []
             for i in range(0, len(dataset.texts), 50):
@@ -338,15 +338,15 @@ class WatsonAssistant(Vendor):
 
         with requests.Session() as session:
             session.auth = requests.auth.HTTPBasicAuth(
-                "apikey", self.assistant.authenticator.token_manager.apikey
+                "apikey", self._assistant.authenticator.token_manager.apikey
             )
             session.headers.update({"Content-Type": "application/json"})
             url = "{url}/v1/workspaces/{ws_id}/message?version={version}".format(
-                url=self.assistant.service_url,
-                ws_id=self.workspace_id,
-                version=self.assistant.version,
+                url=self._assistant.service_url,
+                ws_id=self._workspace_id,
+                version=self._assistant.version,
             )
-            with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
                 responses = list(
                     tqdm(
                         executor.map(get_response, dataset.texts),

--- a/nlubridge/vendors/watson_assistant.py
+++ b/nlubridge/vendors/watson_assistant.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class WatsonAssistant(Vendor):
-
     def __init__(
         self,
         api_key=None,

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     },
     packages=find_packages(),
     python_requires=">=3, <3.9",
-    install_requires=["sklearn", "python-dotenv", "lazy-imports", "ratelimit"],
+    install_requires=["scikit-learn", "python-dotenv", "lazy-imports", "ratelimit"],
     extras_require={
         "watson": ["ibm_watson", "tqdm", "requests"],
         "fasttext": ["fasttext"],

--- a/tests/test_vendors.py
+++ b/tests/test_vendors.py
@@ -39,6 +39,16 @@ def assert_multiple_utterances_predicted(vendor, train_data):
 # -----------------------------
 
 
+def test_vendor_attributes():
+    from nlubridge.vendors.tfidf_intent_classifier import TfidfIntentClassifier
+
+    clf = TfidfIntentClassifier()
+    assert clf.name == "TfidfIntentClassifier"
+    assert clf.alias == "TfidfIntentClassifier"
+    clf.alias = "tfidf"
+    assert clf.alias == "tfidf"
+
+
 def test_tfidf(train_data):
     from nlubridge.vendors.tfidf_intent_classifier import TfidfIntentClassifier
 

--- a/tests/test_watson_vendor.py
+++ b/tests/test_watson_vendor.py
@@ -35,7 +35,7 @@ def test_watson(train_data):
     # test test_intent() (non-bulk)
     test_ds = NluDataset(["Ich habe kein DSL und telefon"])
     watson.set_bulk(False)
-    assert watson.use_bulk is False
+    assert watson._use_bulk is False
     preds = watson.test_intent(test_ds)
     assert isinstance(preds, list)
     assert len(preds) == 1

--- a/tests/test_watson_vendor_mocked.py
+++ b/tests/test_watson_vendor_mocked.py
@@ -60,7 +60,7 @@ def test_watson_mocked(train_data, mocker):
 
     # test watson.set_bulk()
     watson.set_bulk(False)
-    assert watson.use_bulk is False
+    assert watson._use_bulk is False
 
 
 class ResultMock:


### PR DESCRIPTION
Fixes https://github.com/telekom/nlu-bridge/issues/25

So far, Vendor inherited from sklearn BaseEstimator and ClassifierMixin, from which the problematic __repr__ method was inherited. I now removed those as the purpose of subclassing from those was not clear and as far as I can see used nowhere.